### PR TITLE
Specify what is using in SpecialMatrices

### DIFF
--- a/src/FractionalCalculus.jl
+++ b/src/FractionalCalculus.jl
@@ -2,7 +2,8 @@ module FractionalCalculus
 
 using QuadGK
 using SpecialFunctions: gamma
-using LinearAlgebra, InvertedIndices, SpecialMatrices
+using LinearAlgebra, InvertedIndices
+using SpecialMatrices: Vandermonde
 using SymbolicUtils, SymbolicUtils.Rewriters
 using Symbolics
 


### PR DESCRIPTION
Hi, I am helping maintain `SpecialMatrices.jl` and we are making some possibly breaking changes over there and we wanted to make sure they won't break registered packages that depend on it.  This is one of 2 such packages.
It took a while to figure out what you are actually using here from SM.
I know it is pretty common to just drop a lot of `using XYZ` statements in the main project file,
but that approach makes it hard for others to know what specifically is being used here.
This PR simply makes it clear.  Thanks.